### PR TITLE
Nested schemas

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -10,7 +10,7 @@ function extractDefaults (fields) {
     .reduce((defaults, [fieldName, field]) => {
       const value = field.defaultValue;
       if (!isNil(value)) {
-        defaults[fieldName] = field.type.cast(value);
+        defaults[fieldName] = field.cast(value);
       }
       return defaults;
     }, {});
@@ -19,15 +19,20 @@ function extractDefaults (fields) {
 function attachCore (Model, instance) {
   Model.instance = instance;
 
-  Model.create = async function (data) {
+  Model.create = async function (data, { transaction } = {}) {
     const client = instance.client;
     const document = new Model(data);
     await document.validate();
 
     let result;
+    let query = client.table(Model.tableName)
+      .insert(document.data, 'id');
+    if (transaction) {
+      query = query.transacting(transaction);
+    }
+
     try {
-      result = await client.table(Model.tableName)
-        .insert(document.data, 'id');
+      result = await query;
     } catch (err) {
       throw castError(err);
     }
@@ -51,23 +56,34 @@ function attachCore (Model, instance) {
     return await Model.findOne({ id });
   };
 
-  Model.remove = async function (filters) {
+  Model.remove = async function (filters, { transaction } = {}) {
     if (!filters) {
       throw await new Error('Model.remove() requires conditions');
     }
     const client = instance.client;
-    const result = await client.table(Model.tableName)
+    let query = client.table(Model.tableName)
       .where(filters)
       .del();
+    if (transaction) {
+      query = query.transacting(transaction);
+    }
+
+    const result = await query;
     return {
       nModified: result
     };
   };
 
-  Model.update = async function (filters, changes) {
+  Model.update = async function (filters, changes, { transaction } = {}) {
     const client = instance.client;
-    const result = await client.table(Model.tableName)
-      .update(changes);
+    let query = client.table(Model.tableName)
+      .update(changes)
+      .where(filters);
+    if (transaction) {
+      query = query.transacting(transaction);
+    }
+
+    const result = await query;
     return {
       nModified: result
     };
@@ -120,6 +136,7 @@ function modelFactory (instance, name, schema) {
     }
   }
 
+  Item.modelName = name;
   Item.tableName = sanitizeName(name);
   Item.schema = schema;
   Item.prototype.Model = Item;
@@ -146,7 +163,7 @@ function modelFactory (instance, name, schema) {
           }
         }
 
-        const cleaned = field.type.cast(value);
+        const cleaned = field.cast(value);
         if (!isUndefined(cleaned)) {
           this.data[fieldName] = cleaned;
         }

--- a/src/field.js
+++ b/src/field.js
@@ -7,27 +7,101 @@ const {
 } = require('./utils');
 const { ValidationError } = require('./error');
 
+function validateField (field, value) {
+  if (isUndefined(value)) {
+    if (field.required) {
+      throw new ValidationError(`Field ${field.fieldName} is required`, {
+        field: field.fieldName
+      });
+    }
+    return;
+  }
+  if (!field.type.isValid(value)) {
+    throw new ValidationError(`Invalid value of field ${field.fieldName}: ${value}`, {
+      field: field.fieldName,
+      value
+    });
+  }
+  if (field.validator && isFunction(field.validator)) {
+    if (!field.validator(value)) {
+      const defaultMessage = `Validation failed on ${field.fieldName}: ${value}`;
+      const messageText = field.validationTemplate && template(field.validationTemplate, {
+        VALUE: value
+      });
+      throw new ValidationError(messageText || defaultMessage, {
+        field: field.fieldName,
+        value
+      });
+    }
+  }
+}
+
+function getRef (field) {
+  if (!field.ref) {
+    return null;
+  }
+  return field.schema.instance.model(field.ref);
+}
+
 class Field {
   constructor (schema, fieldName, definition) {
     this.schema = schema; // schema.instance is available once the model is created
-    this.name = fieldName;
+    this.fieldName = fieldName;
     this.columnName = sanitizeName(fieldName);
-    this.type = definition.type;
+
     this.ref = definition.ref;
     if (this.ref) {
       this.refTableName = sanitizeName(this.ref);
     }
+
     this.required = definition.required;
+
     this.unique = definition.unique;
+
     this.hasIndex = !!definition.index;
     this.indexType = this.hasIndex
       ? (isString(definition.index) ? definition.index : 'btree')
       : 'btree';
-    this.defaultValue = this.type.cast(definition.default);
+
     if (definition.validate) {
       this.validator = definition.validate.validator;
       this.validationTemplate = definition.validate.message;
     }
+
+    if (Array.isArray(definition.type)) {
+      this.type = definition.type[0];
+
+      this.defaultValue = [];
+      this.isNested = true;
+    } else {
+      this.type = definition.type;
+      this.defaultValue = this.type.cast(definition.default);
+      this.isNested = false;
+    }
+  }
+
+  cast (value) {
+    if (!this.isNested) {
+      if (this.ref) {
+        const Ref = getRef(this);
+        if (value instanceof Ref) {
+          return this.type.cast(value.id);
+        }
+      }
+      return this.type.cast(value);
+    }
+
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    const Model = this.type;
+    return value.map((item) => {
+      if (item instanceof Model) {
+        return item;
+      }
+      return new Model(Model.schema.cast(item));
+    });
   }
 
   getConstraints () {
@@ -48,32 +122,19 @@ class Field {
   }
 
   validate (value) {
-    if (isUndefined(value)) {
-      if (this.required) {
-        throw new ValidationError(`Field ${this.name} is required`, {
-          field: this.name
-        });
+    if (!this.isNested) {
+      const Ref = getRef(this);
+      if (Ref && value instanceof Ref) {
+        return value.validate();
       }
-      return;
+      return validateField(this, value);
     }
-    if (!this.type.isValid(value)) {
-      throw new ValidationError(`Invalid value of field ${this.name}: ${value}`, {
-        field: this.name,
-        value
+    if (value && !Array.isArray(value)) {
+      throw new ValidationError(`Nested field ${this.fieldName} should be a list of ${this.type.modelName}`, {
+        field: this.fieldName
       });
     }
-    if (this.validator && isFunction(this.validator)) {
-      if (!this.validator(value)) {
-        const defaultMessage = `Validation failed on ${this.name}: ${value}`;
-        const messageText = this.validationTemplate && template(this.validationTemplate, {
-          VALUE: value
-        });
-        throw new ValidationError(messageText || defaultMessage, {
-          field: this.name,
-          value
-        });
-      }
-    }
+    value.forEach((item) => item.validate());
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,12 @@ class Mongres {
     this.namespace = 'public';
   }
 
+  get dbSchema () {
+    return this.namespace
+      ? this.client.schema.withSchema(this.namespace)
+      : this.client.schema;
+  }
+
   connect (connectionInfo) {
     this.client = knex(connectionInfo);
     return createTables(this);

--- a/src/lib/model.js
+++ b/src/lib/model.js
@@ -1,0 +1,28 @@
+function serialize (document) {
+  const { instance, schema } = document;
+  const data = Object.keys(schema.fields)
+    .reduce((data, fieldName) => {
+      const field = schema.fields[fieldName];
+      const value = document[fieldName];
+
+      if (field.ref) {
+        const Ref = instance.model(field.ref);
+        if (Ref && value instanceof Ref) {
+          data[fieldName] = value.id;
+          return data;
+        }
+      }
+
+      if (field.isNested) {
+        return data;
+      }
+
+      data[fieldName] = value;
+      return data;
+    }, {});
+  return data;
+}
+
+module.exports = {
+  serialize
+};

--- a/src/lib/model.js
+++ b/src/lib/model.js
@@ -1,3 +1,14 @@
+function getBackRefFields (Model, schema) {
+  const fields = Object.values(schema.fields);
+  const backRefFields = fields.reduce((backRefFields, field) => {
+    if (field.refTableName === Model.tableName) {
+      backRefFields.push(field);
+    }
+    return backRefFields;
+  }, []);
+  return backRefFields;
+}
+
 function serialize (document) {
   const { instance, schema } = document;
   const data = Object.keys(schema.fields)
@@ -24,5 +35,6 @@ function serialize (document) {
 }
 
 module.exports = {
+  getBackRefFields,
   serialize
 };

--- a/src/lib/query.js
+++ b/src/lib/query.js
@@ -48,7 +48,7 @@ function getWhereBuilder (query, fieldName, filter) {
     const [tableName, columnName] = fieldName.split('.');
     const Model = getTableModel(query, tableName);
     const field = Model.schema.fields[columnName];
-    return (builder) => builder.where(fieldName, field.type.cast(filter));
+    return (builder) => builder.where(fieldName, field.cast(filter));
   }
 
   return (builder) => {

--- a/src/model.js
+++ b/src/model.js
@@ -32,7 +32,21 @@ class Model {
   }
 
   toObject () {
-    return Object.assign({}, this.data);
+    return Object.values(this.schema.fields)
+      .reduce((data, field) => {
+        const fieldName = field.fieldName;
+        if (field.isNested) {
+          data[fieldName] = this[fieldName].map((item) => item.toObject());
+        } else {
+          const value = this[fieldName];
+          if (value instanceof Model) {
+            data[fieldName] = value.toObject();
+          } else if (!isUndefined(value)) {
+            data[fieldName] = value;
+          }
+        }
+        return data;
+      }, {});
   }
 
   async populate (fieldName) {

--- a/src/model.js
+++ b/src/model.js
@@ -1,5 +1,5 @@
 const { invoke, invokeSeries, isUndefined } = require('./utils');
-const { serialize } = require('./lib/model');
+const { getBackRefFields, serialize } = require('./lib/model');
 
 async function invokeMiddleware (document, hook, middleware, isBlocking) {
   const fns = middleware.map(mid => () => mid.execute(hook, document));
@@ -7,17 +7,6 @@ async function invokeMiddleware (document, hook, middleware, isBlocking) {
     return await invokeSeries(fns);
   }
   return invoke(fns);
-}
-
-function getBackRefFields (Model, schema) {
-  const fields = Object.values(schema.fields);
-  const backRefFields = fields.reduce((backRefFields, field) => {
-    if (field.refTableName === Model.tableName) {
-      backRefFields.push(field);
-    }
-    return backRefFields;
-  }, []);
-  return backRefFields;
 }
 
 async function saveNestedFields (transaction, document) {

--- a/src/schema.js
+++ b/src/schema.js
@@ -34,7 +34,7 @@ class Schema {
         if (isNil(value)) {
           return cleaned;
         }
-        value = field.type.cast(value);
+        value = field.cast(value);
         if (!isUndefined(value)) {
           cleaned[fieldName] = value;
         }

--- a/test/tests/model/instanceFunctions.spec.js
+++ b/test/tests/model/instanceFunctions.spec.js
@@ -258,6 +258,60 @@ describe('model/instanceFunctions', () => {
     });
   });
 
+  describe('#toObject()', () => {
+    it('Represents the model data as a plain object', () => {
+      const square = new Square({
+        height: 5,
+        width: 10
+      });
+      expect(square.toObject()).to.deep.equal({
+        height: 5,
+        width: 10
+      });
+    });
+
+    it('Returns a copy of the data', () => {
+      const square = new Square({
+        height: 5,
+        width: 10
+      });
+      const data = square.toObject();
+      data.height = 20;
+      expect(square.height).to.equal(5);
+    });
+
+    it('Supports nested schemas', async () => {
+      const start = new Point({
+        x: 1,
+        y: 2
+      });
+      const end = new Point({
+        x: 3,
+        y: 4
+      });
+      await start.save();
+      await end.save();
+      const line = new Line({
+        start: start.id,
+        end: end.id
+      });
+      await line.populate('start');
+      await line.populate('end');
+      expect(line.toObject()).to.deep.equal({
+        start: {
+          x: 1,
+          y: 2,
+          id: start.id
+        },
+        end: {
+          x: 3,
+          y: 4,
+          id: end.id
+        }
+      });
+    });
+  });
+
   describe('#validate()', () => {
     it('Enforces required fields', () => {
       const square = new Square({

--- a/test/tests/nestedSchema.spec.js
+++ b/test/tests/nestedSchema.spec.js
@@ -110,4 +110,45 @@ describe('Nested Schemas', () => {
       expect(line.points[1]).to.be.instanceof(Point);
     });
   });
+
+  describe('Model#find()', () => {
+    let existingLine1;
+    let existingLine2;
+
+    beforeEach(async () => {
+      existingLine1 = new Line({
+        points: [{
+          x: 1,
+          y: 2
+        }, {
+          x: 3,
+          y: 4
+        }]
+      });
+      existingLine2 = new Line({
+        points: [{
+          x: 5,
+          y: 6
+        }, {
+          x: 7,
+          y: 8
+        }, {
+          x: 9,
+          y: 10
+        }]
+      });
+      await existingLine1.save();
+      await existingLine2.save();
+    });
+
+    it('Populates subdocuments on retrieval', async () => {
+      const lines = await Line.find();
+      const line1 = lines.find(line => line.id === existingLine1.id);
+      const line2 = lines.find(line => line.id === existingLine2.id);
+
+      expect(lines.length).to.equal(2);
+      expect(line1.points.length).to.equal(2);
+      expect(line2.points.length).to.equal(3);
+    });
+  });
 });

--- a/test/tests/nestedSchema.spec.js
+++ b/test/tests/nestedSchema.spec.js
@@ -83,4 +83,31 @@ describe('Nested Schemas', () => {
       expect(savedPoints[1].line).to.equal(savedLine.id);
     });
   });
+
+  describe('Model#findOne()', () => {
+    let existingLine;
+
+    beforeEach(async () => {
+      existingLine = new Line({
+        points: [{
+          x: 1,
+          y: 2
+        }, {
+          x: 3,
+          y: 4
+        }]
+      });
+      await existingLine.save();
+    });
+
+    it('Populates subdocuments on retrieval', async () => {
+      const line = await Line.findOne({
+        id: existingLine.id
+      });
+      expect(line).to.be.ok;
+      expect(line.points.length).to.equal(2);
+      expect(line.points[0]).to.be.instanceof(Point);
+      expect(line.points[1]).to.be.instanceof(Point);
+    });
+  });
 });

--- a/test/tests/nestedSchema.spec.js
+++ b/test/tests/nestedSchema.spec.js
@@ -5,6 +5,7 @@ describe('Nested Schemas', () => {
   let mongres;
   let Point;
   let Line;
+  let Shape;
 
   beforeEach(async () => {
     await helpers.table.dropTables();
@@ -26,11 +27,22 @@ describe('Nested Schemas', () => {
     Point = mongres.model('Point', pointSchema);
 
     const lineSchema = new Schema({
+      shape: {
+        type: Schema.Types.Integer(),
+        ref: 'Shape'
+      },
       points: {
         type: [Point]
       }
     });
     Line = mongres.model('Line', lineSchema);
+
+    const shapeSchema = new Schema({
+      lines: {
+        type: [Line]
+      }
+    });
+    Shape = mongres.model('Shape', shapeSchema);
 
     await mongres.connect(helpers.connectionInfo);
   });
@@ -58,10 +70,8 @@ describe('Nested Schemas', () => {
   });
 
   describe('Model#save()', () => {
-    let line;
-
-    beforeEach(async () => {
-      line = new Line({
+    it('Saves any new subdocuments', async () => {
+      const line = new Line({
         points: [{
           x: 1,
           y: 2
@@ -71,24 +81,51 @@ describe('Nested Schemas', () => {
         }]
       });
       await line.save();
-    });
-
-    it('Saves any new subdocuments', async () => {
       const savedLine = await helpers.query.findOne(Line.tableName, {
         id: line.id
       });
       const savedPoints = await helpers.query.find(Point.tableName);
+
       expect(savedPoints.length).to.equal(2);
       expect(savedPoints[0].line).to.equal(savedLine.id);
       expect(savedPoints[1].line).to.equal(savedLine.id);
     });
+
+    it('Saves new deeply nested subdocuments', async () => {
+      const shape = new Shape({
+        lines: [{
+          points: [{
+            x: 1,
+            y: 2
+          }, {
+            x: 3,
+            y: 4
+          }]
+        }, {
+          points:[{
+            x: 5,
+            y: 6
+          }, {
+            x: 7,
+            y: 8
+          }]
+        }]
+      });
+      await shape.save();
+
+      const savedLines = await helpers.query.find(Line.tableName);
+      const savedPoints = await helpers.query.find(Point.tableName);
+
+      expect(savedLines.length).to.equal(2);
+      expect(savedLines[0].shape).to.equal(shape.id);
+      expect(savedLines[1].shape).to.equal(shape.id);
+      expect(savedPoints.length).to.equal(4);
+    });
   });
 
   describe('Model#findOne()', () => {
-    let existingLine;
-
-    beforeEach(async () => {
-      existingLine = new Line({
+    it('Populates subdocuments on retrieval', async () => {
+      const existingLine = new Line({
         points: [{
           x: 1,
           y: 2
@@ -98,16 +135,51 @@ describe('Nested Schemas', () => {
         }]
       });
       await existingLine.save();
-    });
-
-    it('Populates subdocuments on retrieval', async () => {
       const line = await Line.findOne({
         id: existingLine.id
       });
+
       expect(line).to.be.ok;
       expect(line.points.length).to.equal(2);
       expect(line.points[0]).to.be.instanceof(Point);
       expect(line.points[1]).to.be.instanceof(Point);
+    });
+
+    it('Populates deeply nested subdocuments on retrieval', async () => {
+      const existingShape = new Shape({
+        lines: [{
+          points: [{
+            x: 1,
+            y: 2
+          }, {
+            x: 3,
+            y: 4
+          }]
+        }, {
+          points:[{
+            x: 5,
+            y: 6
+          }, {
+            x: 7,
+            y: 8
+          }]
+        }]
+      });
+      await existingShape.save();
+      const shape = await Shape.findOne({
+        id: existingShape.id
+      });
+
+      expect(shape).to.be.ok;
+      expect(shape).to.be.instanceof(Shape);
+      expect(shape.lines.length).to.equal(2);
+      expect(shape.lines[0]).to.be.instanceof(Line);
+      expect(shape.lines[1]).to.be.instanceof(Line);
+      expect(shape.lines[0].points.length).to.equal(2);
+      expect(shape.lines[0].points[0]).to.be.instanceof(Point);
+      expect(shape.lines[0].points[1]).to.be.instanceof(Point);
+      expect(shape.lines[1].points[0]).to.be.instanceof(Point);
+      expect(shape.lines[1].points[1]).to.be.instanceof(Point);
     });
   });
 

--- a/test/tests/nestedSchema.spec.js
+++ b/test/tests/nestedSchema.spec.js
@@ -1,0 +1,86 @@
+const helpers = require('../helpers');
+const { Mongres, Schema } = require('../../src');
+
+describe('Nested Schemas', () => {
+  let mongres;
+  let Point;
+  let Line;
+
+  beforeEach(async () => {
+    await helpers.table.dropTables();
+
+    mongres = new Mongres();
+
+    const pointSchema = new Schema({
+      line: {
+        type: Schema.Types.Integer(),
+        ref: 'Line'
+      },
+      x: {
+        type: Schema.Types.Integer()
+      },
+      y: {
+        type: Schema.Types.Integer()
+      }
+    });
+    Point = mongres.model('Point', pointSchema);
+
+    const lineSchema = new Schema({
+      points: {
+        type: [Point]
+      }
+    });
+    Line = mongres.model('Line', lineSchema);
+
+    await mongres.connect(helpers.connectionInfo);
+  });
+
+  afterEach(() => {
+    return mongres.disconnect();
+  });
+
+  describe('Model#constructor()', () => {
+    it('Nested schemas are cast to new instances', () => {
+      const line = new Line({
+        points: [{
+          x: 1,
+          y: 2
+        }, {
+          x: 3,
+          y: 4
+        }]
+      });
+      expect(line).to.be.instanceof(Line);
+      expect(line.points[0].x).to.equal(1);
+      expect(line.points[0]).to.be.instanceof(Point);
+      expect(line.points[1]).to.be.instanceof(Point);
+    });
+  });
+
+  describe('Model#save()', () => {
+    let line;
+
+    beforeEach(async () => {
+      line = new Line({
+        points: [{
+          x: 1,
+          y: 2
+        }, {
+          x: 3,
+          y: 4
+        }]
+      });
+      await line.save();
+    });
+
+    it('Saves any new subdocuments', async () => {
+      const savedLine = await helpers.query.findOne(Line.tableName, {
+        id: line.id
+      });
+      const savedPoints = await helpers.query.find(Point.tableName);
+      expect(savedPoints.length).to.equal(2);
+      expect(savedPoints[0].line).to.equal(savedLine.id);
+      expect(savedPoints[1].line).to.equal(savedLine.id);
+    });
+  });
+});


### PR DESCRIPTION
Currently only supports nesting a model of a given type on a single attachment point on the document. Attaching the same type to multiple points of the same document would require the addition of another field in the nested schema that specifies the attachment point.